### PR TITLE
label_colormap to return 0 and num_colors

### DIFF
--- a/napari/utils/colormaps/colormap_utils.py
+++ b/napari/utils/colormaps/colormap_utils.py
@@ -384,11 +384,14 @@ def label_colormap(num_colors=256, seed=0.5):
     """
     # Starting the control points slightly above 0 and below 1 is necessary
     # to ensure that the background pixel 0 is transparent
-    midpoints = np.linspace(0.00001, 1 - 0.00001, num_colors - 1)
+    midpoints = np.linspace(0.00001, 1 - 0.00001, num_colors)
     control_points = np.concatenate(([0], midpoints, [1.0]))
     # make sure to add an alpha channel to the colors
     colors = np.concatenate(
-        (_color_random(num_colors, seed=seed), np.full((num_colors, 1), 1)),
+        (
+            _color_random(num_colors + 1, seed=seed),
+            np.full((num_colors + 1, 1), 1),
+        ),
         axis=1,
     )
     colors[0, :] = 0  # ensure alpha is 0 for label 0


### PR DESCRIPTION
# Description
This fixes the issue https://github.com/napari/napari/pull/5154#issuecomment-1263148405 with a single surface:
```
import napari
from napari.utils.colormaps import label_colormap

import numpy as np

vertices = np.array([[0, 0], [0, 20], [10, 0], [10, 10]])
faces = np.array([[0, 1, 2], [1, 2, 3]])
values = np.linspace(0, 1, len(vertices))
surface = (vertices, faces, values)

viewer = napari.view_surface(surface, colormap=label_colormap(1))  # add the surface
```
And stardist-napari seems happy too although I can't replicate the old issue https://github.com/napari/napari/issues/2352

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [x] example: all tests pass with my change: I ran pytest locally
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
