### PR TITLE
Fix layer slicer tests

### DIFF
--- a/napari/components/_layer_slicer.py
+++ b/napari/components/_layer_slicer.py
@@ -153,7 +153,7 @@ class _LayerSlicer:
         sync_layers = []
         for layer in layers:
             if isinstance(layer, _AsyncSliceable) and not self._force_sync:
-                logger.debug(f'Async slicing {layer.name}')
+                logger.debug('Async slicing: %s', layer)
                 requests[layer] = layer._make_slice_request(dims)
             else:
                 sync_layers.append(layer)
@@ -163,7 +163,7 @@ class _LayerSlicer:
 
         # submit the sync layers (purposefully placed after async submission)
         for layer in sync_layers:
-            logger.debug(f'Sync slicing {layer.name}')
+            logger.debug('Sync slicing: %s', layer)
             layer._slice_dims(dims.point, dims.ndisplay, dims.order)
 
         # store task for cancellation logic

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -894,7 +894,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
     def _set_view_slice(self):
         raise NotImplementedError()
 
-    def _slice_dims(self, point=None, ndisplay=2, order=None, force=False):
+    def _slice_dims(self, point=None, ndisplay=2, order=None):
         """Slice data with values from a global dims model.
 
         Note this will likely be moved off the base layer soon.


### PR DESCRIPTION
# Description
This makes the tests defined in `test_layer_slicer.py` pass again after the changes on the integration branch.

I also distinguished sync/async counts in the fake async layer we use for testing and updated the assertions appropriately. Kim should take a look at those changes before we make the main PR ready to review.

I also added a test around shutdown and expectations. We probably want to downgrade from error to warning.